### PR TITLE
Fixes

### DIFF
--- a/src/main/java/com/me/tft_02/soulbound/util/ItemUtils.java
+++ b/src/main/java/com/me/tft_02/soulbound/util/ItemUtils.java
@@ -231,9 +231,14 @@ public class ItemUtils {
 
     private static ItemStack updateOldLore(Player player, ItemStack itemStack) {
         ItemMeta itemMeta = itemStack.getItemMeta();
+        if(itemMeta != null){
+            if(!itemMeta.hasLore()){
+                return itemStack;
+            }
+        }
         List<String> itemLore = itemMeta.getLore();
-
-        if (itemLore.size() < 3) {
+        
+        if (itemLore.size() - 1 < StringUtils.getIndexOfSoulbound(itemLore) + 2) {
             return itemStack;
         }
 


### PR DESCRIPTION
Had to fix the old .size < 3   because of array index out of bound exceptions
When lore was added to an item, that would falsify the continuation of the method
because of the plugin thinking the UUID was at that line, just because a lore had XXX amount
of lines. So we check to see if there are two lines 

Example lore with .size of 5:
Timmy (0)
Eats (1)
Pie (2)
Soulbound (3)
Ktar5 (4)

There is no uuid, but you continue the method like there is, so... iFix4u
This should work as a nice fix.
